### PR TITLE
ufw reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Modify the UFW configuration file `/etc/ufw/after.rules` and add the following r
     COMMIT
     # END UFW AND DOCKER
 
-Using command `sudo systemctl restart ufw** to restart UFW after changing the file. Now the public network can't access any published docker ports, the container and the private network can visit each other normally, and the containers can also access the external network from inside. **There may be some unknown reasons cause the UFW rules will not take effect after restart UFW, please reboot servers. **
+Using command `sudo systemctl restart ufw` or `sudo ufw reload` to restart UFW after changing the file. Now the public network can't access any published docker ports, the container and the private network can visit each other normally, and the containers can also access the external network from inside. **There may be some unknown reasons cause the UFW rules will not take effect after restart UFW, please reboot servers.**
 
 If you want to allow public networks to access the services provided by the Docker container, for example, the service port of a container is `80`. Run the following command to allow the public networks to access this service:
 


### PR DESCRIPTION
On my Ubuntu 18.04 restarting the service via `systemctl` indeed was not not enough to apply the rule changes. A reboot as suggested by you probably would have worked, but I was also able to use `ufw reload` to do it without one.

Sadly I cannot provide Chinese translations for this change.