### PR TITLE
Fix (almost) always truthy regexp in ufw-docker--list

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -167,6 +167,18 @@ DOCKERFILE
         done
 
         ufw-docker service allow public_service 80/tcp
+
+        for name in public_multiport; do
+            webapp="${name}_service"
+            port_1="23080"
+            port_2="23443"
+            if docker service inspect "$webapp" &>/dev/null; then docker service rm "$webapp"; fi
+            docker service create --name "$webapp" \
+                -p "${port_1}:80" -p "${port_2}:443" --env name="$webapp" --replicas 3 #{private_registry}/chaifeng/hostname-webapp
+        done
+
+        ufw-docker service allow public_multiport 443/tcp
+        ufw-docker service allow public_multiport 80/tcp
     SHELL
   end
 
@@ -202,6 +214,9 @@ DOCKERFILE
 
         test-webapp "$server:29090"
         ! test-webapp "$server:9000"
+
+        test-webapp "$server:23080"
+        test-webapp "$server:23443"
 
         echo "====================="
         echo "      TEST DONE      "

--- a/test/ufw-docker.test.sh
+++ b/test/ufw-docker.test.sh
@@ -474,7 +474,7 @@ test-ufw-docker--list-name() {
     ufw-docker--list foo
 }
 test-ufw-docker--list-name-assert() {
-    grep "# allow foo\\( [[:digit:]]\\+\\/\\(tcp\\|udp\\)\\)\\?\\( [[:graph:]]*\\)\\?\$"
+    grep "# allow foo\\( [[:digit:]]\\+\\/\\(tcp\\|udp\\)\\)\\( [[:graph:]]*\\)\$"
 }
 
 test-ufw-docker--list-name-udp() {
@@ -483,7 +483,7 @@ test-ufw-docker--list-name-udp() {
     ufw-docker--list foo "" udp
 }
 test-ufw-docker--list-name-udp-assert() {
-    grep "# allow foo\\( [[:digit:]]\\+\\/\\(tcp\\|udp\\)\\)\\?\\( [[:graph:]]*\\)\\?\$"
+    grep "# allow foo\\( [[:digit:]]\\+\\/\\(tcp\\|udp\\)\\)\\( [[:graph:]]*\\)\$"
 }
 
 
@@ -493,7 +493,7 @@ test-ufw-docker--list-name-80() {
     ufw-docker--list foo 80
 }
 test-ufw-docker--list-name-80-assert() {
-    grep "# allow foo\\( 80\\/tcp\\)\\?\\( [[:graph:]]*\\)\\?\$"
+    grep "# allow foo\\( 80\\/tcp\\)\\( [[:graph:]]*\\)\$"
 }
 
 
@@ -503,7 +503,7 @@ test-ufw-docker--list-name-80-udp() {
     ufw-docker--list foo 80 udp
 }
 test-ufw-docker--list-name-80-udp-assert() {
-    grep "# allow foo\\( 80\\/udp\\)\\?\\( [[:graph:]]*\\)\\?\$"
+    grep "# allow foo\\( 80\\/udp\\)\\( [[:graph:]]*\\)\$"
 }
 
 

--- a/test/ufw-docker.test.sh
+++ b/test/ufw-docker.test.sh
@@ -507,6 +507,29 @@ test-ufw-docker--list-name-80-udp-assert() {
 }
 
 
+test-ufw-docker--list-grep-without-network() {
+    @mocktrue ufw status numbered
+    @mockfalse grep "# allow foo\\( 80\\/udp\\)\\( [[:graph:]]*\\)\$"
+    load-ufw-docker-function ufw-docker--list
+    ufw-docker--list foo 80 udp
+}
+test-ufw-docker--list-grep-without-network-assert() {
+    grep "# allow foo\\( 80\\/udp\\)\$"
+}
+
+
+test-ufw-docker--list-grep-without-network-and-port() {
+    @mocktrue ufw status numbered
+    @mockfalse grep "# allow foo\\( 80\\/udp\\)\\( [[:graph:]]*\\)\$"
+    @mockfalse grep "# allow foo\\( 80\\/udp\\)\$"
+    load-ufw-docker-function ufw-docker--list
+    ufw-docker--list foo 80 udp
+}
+test-ufw-docker--list-grep-without-network-and-port-assert() {
+    grep "# allow foo\$"
+}
+
+
 test-ufw-docker--list-number() {
     @mocktrue ufw-docker--list foo 53 udp
 

--- a/ufw-docker
+++ b/ufw-docker
@@ -42,7 +42,9 @@ function ufw-docker--list() {
        NETWORK="[[:graph:]]*"
     fi
 
-    ufw status numbered | grep "# allow ${INSTANCE_NAME}\\( ${INSTANCE_PORT}\\/${PROTO}\\)\\?\\( ${NETWORK}\\)\\?\$"
+    ufw status numbered | grep "# allow ${INSTANCE_NAME}\\( ${INSTANCE_PORT}\\/${PROTO}\\)\\( ${NETWORK}\\)\$" ||  \
+    ufw status numbered | grep "# allow ${INSTANCE_NAME}\\( ${INSTANCE_PORT}\\/${PROTO}\\)\$" || \
+    ufw status numbered | grep "# allow ${INSTANCE_NAME}\$"
 }
 
 function ufw-docker--list-number() {


### PR DESCRIPTION
Because of the question mark after capture closures in grep command, everything that has (existing in ufw list) INSTANCE_NAME, results as truthy value.
For this reason when we try to add two entries for the same service, but with different ports eg.:
```
$ ufw-docker service allow nginx 80/tcp
$ ufw-docker service allow nginx 443/tcp
```
the second command will override previous one because of the same service name.

I'm not proficient with using grep, so I chose a method to split the regular expression into three correct cases.