### PR TITLE
Bump Ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG docker_version="20.10.17"
 


### PR DESCRIPTION
After update Ubuntu to version 22.04 my `ufw-docker` lost its ability to create `ufw-docker-agent` service because of `ERROR: UFW is disabled or you are not root user` error.

A change of Ubuntu version in Dockerfile resolves this problem.