### PR TITLE
Adds check for docker executable and adds snap to path

### DIFF
--- a/test/ufw-docker.test.sh
+++ b/test/ufw-docker.test.sh
@@ -15,6 +15,9 @@ source "$working_dir"/bach/bach.sh
     @mock iptables --version
     @mocktrue grep -F '(legacy)'
 
+    @mocktrue docker -v
+    @mock docker -v === @stdout Docker version 0.0.0, build dummy
+
     @ignore remove_blank_lines
     @ignore echo
     @ignore err

--- a/test/ufw-docker.test.sh
+++ b/test/ufw-docker.test.sh
@@ -101,6 +101,17 @@ test-ufw-is-disabled-assert() {
 }
 
 
+test-docker-is-installed() {
+    @mockfalse docker -v
+
+    ufw-docker
+}
+test-docker-is-installed-assert() {
+    die "Docker executable not found."
+    ufw-docker--help
+}
+
+
 test-ufw-docker-status() {
     ufw-docker status
 }

--- a/ufw-docker
+++ b/ufw-docker
@@ -5,7 +5,7 @@ set -euo pipefail
 LANG=en_US.UTF-8
 LANGUAGE=en_US:
 LC_ALL=en_US.UTF-8
-PATH="/bin:/usr/bin:/sbin:/usr/sbin"
+PATH="/bin:/usr/bin:/sbin:/usr/sbin:/snap/bin/"
 
 GREP_REGEXP_INSTANCE_NAME="[-_.[:alnum:]]\\+"
 DEFAULT_PROTO=tcp
@@ -422,6 +422,10 @@ function die() {
 
 if ! ufw status 2>/dev/null | grep -Fq "Status: active" ; then
     die "UFW is disabled or you are not root user, or mismatched iptables legacy/nf_tables, current $(iptables --version)"
+fi
+
+if ! docker -v &> /dev/null; then
+  die "Docker executable not found."
 fi
 
 ufw_action="${1:-help}"


### PR DESCRIPTION
If docker is installed in different folder other than the path variable defined in the script `PATH="/bin:/usr/bin:/sbin:/usr/sbin"`, then docker commands fail because the docker executable is not found. This also leads to inaccurate error message being printed. For example on [line 68](https://github.com/chaifeng/ufw-docker/blob/master/ufw-docker#L68): this will fail with "Docker instance xxx doesn't exist." (Issue #28)